### PR TITLE
Revert hardcoded tanprometheus datasource id

### DIFF
--- a/nginx/managed-grafana-dashboard-for-request-handling-performance.json
+++ b/nginx/managed-grafana-dashboard-for-request-handling-performance.json
@@ -36,7 +36,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
-        "uid": "tanprometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total time for NGINX and upstream servers to process a request and send a response",
       "fieldConfig": {
@@ -82,7 +82,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "tanprometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(\n  0.5,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_request_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
           "interval": "",
@@ -91,7 +91,7 @@
         },
         {
           "datasource": {
-            "uid": "tanprometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(\n  0.95,\n  sum by (le)(\n    rate(\n    nginx_ingress_controller_request_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
           "interval": "",
@@ -100,7 +100,7 @@
         },
         {
           "datasource": {
-            "uid": "tanprometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(\n  0.99,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_request_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
           "interval": "",
@@ -144,7 +144,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
-        "uid": "tanprometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The time spent on receiving the response from the upstream server",
       "fieldConfig": {
@@ -190,7 +190,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "tanprometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(\n  0.5,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
           "instant": false,
@@ -201,7 +201,7 @@
         },
         {
           "datasource": {
-            "uid": "tanprometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(\n  0.95,\n  sum by (le)(\n    rate(\n    nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
           "interval": "",
@@ -210,7 +210,7 @@
         },
         {
           "datasource": {
-            "uid": "tanprometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(\n  0.99,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
           "interval": "",
@@ -254,7 +254,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
-        "uid": "tanprometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -301,7 +301,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "tanprometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "  sum by (method, host, path)(\n    rate(\n      nginx_ingress_controller_request_duration_seconds_count{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n",
           "interval": "",
@@ -346,7 +346,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
-        "uid": "tanprometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "For each path observed, its median upstream response time",
       "fieldConfig": {
@@ -394,7 +394,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "tanprometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(\n  .5,\n  sum by (le, method, host, path)(\n    rate(\n      nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
           "interval": "",
@@ -439,7 +439,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
-        "uid": "tanprometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Percentage of 4xx and 5xx responses among all responses.",
       "fieldConfig": {
@@ -487,7 +487,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "tanprometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum by (method, host, path) (rate(nginx_ingress_controller_request_duration_seconds_count{\n  ingress =~ \"$ingress\",\n  status =~ \"[4-5].*\"\n}[5m])) / sum by (method, host, path) (rate(nginx_ingress_controller_request_duration_seconds_count{\n  ingress =~ \"$ingress\",\n}[5m]))",
           "interval": "",
@@ -532,7 +532,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
-        "uid": "tanprometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "For each path observed, the sum of upstream request time",
       "fieldConfig": {
@@ -580,7 +580,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "tanprometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum by (method, host, path) (rate(nginx_ingress_controller_response_duration_seconds_sum{ingress =~ \"$ingress\"}[5m]))",
           "interval": "",
@@ -625,7 +625,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
-        "uid": "tanprometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -672,7 +672,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "tanprometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "  sum (\n    rate(\n      nginx_ingress_controller_request_duration_seconds_count{\n        ingress =~ \"$ingress\",\n        status =~\"[4-5].*\",\n      }[5m]\n    )\n  ) by(method, host, path, status)\n",
           "interval": "",
@@ -717,7 +717,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
-        "uid": "tanprometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -764,7 +764,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "tanprometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum (\n  rate (\n      nginx_ingress_controller_response_size_sum {\n        ingress =~ \"$ingress\",\n      }[5m]\n  )\n)  by (method, host, path) / sum (\n  rate(\n      nginx_ingress_controller_response_size_count {\n        ingress =~ \"$ingress\",\n      }[5m]\n  )\n) by (method, host, path)\n",
           "hide": false,
@@ -776,7 +776,7 @@
         },
         {
           "datasource": {
-            "uid": "tanprometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "    sum (rate(nginx_ingress_controller_response_size_bucket{\n        ingress =~ \"$ingress\",\n    }[5m])) by (le)\n",
           "hide": true,
@@ -820,7 +820,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
-        "uid": "tanprometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -865,7 +865,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "tanprometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum (\n  rate(\n      nginx_ingress_controller_ingress_upstream_latency_seconds_sum {\n        ingress =~ \"$ingress\",\n      }[5m]\n)) / sum (\n  rate(\n      nginx_ingress_controller_ingress_upstream_latency_seconds_count {\n        ingress =~ \"$ingress\",\n      }[5m]\n  )\n)\n",
           "hide": false,
@@ -918,14 +918,14 @@
       {
         "current": {
           "selected": false,
-          "text": "Managed_Prometheus_tanprometheus",
-          "value": "Managed_Prometheus_tanprometheus"
+          "text": "Managed_Prometheus",
+          "value": "Managed_Prometheus"
         },
         "hide": 0,
         "includeAll": false,
         "label": "datasource",
         "multi": false,
-        "name": "prometheus",
+        "name": "DS_PROMETHEUS",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
@@ -940,8 +940,10 @@
           "value": "tanaks"
         },
         "datasource": {
-          "type": "prometheus",
-          "uid": "${prometheus}"
+
+
+
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(up,cluster)",
         "hide": 0,
@@ -967,8 +969,7 @@
           "value": "$__all"
         },
         "datasource": {
-          "type": "prometheus",
-          "uid": "${prometheus}"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(nginx_ingress_controller_requests{cluster=~\"$cluster\"},ingress)",
         "hide": 0,


### PR DESCRIPTION
## Purpose
Kubernetes/NGINX Ingress Controller/Request Handling Performance wasn't working in my environment.

Corrected the issue by reverting the hardcoded "tanprometheus" datasource id.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Import  managed-grafana-dashboard-for-request-handling-performance.json into an AKS connected Managed Grafana.

## What to Check
Actually displays some data.

## Other Information
No guarantees otherwise, but works for me now.